### PR TITLE
Move to MultiJson for jruby compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ m.things
 
 Use this property when you want to store your value, serialized as JSON. By default, the value will be deserialized back into a ruby datatype (e.g. `Hash` or `Array`) when loaded from the database. Set the `:load_raw_value` to `true`, as shown above, to get the raw JSON value as a string instead.
 
-Please note: JSON de/serializtion is being handled by the `Oj` gem, which is the fastest implementation for ruby that you can find. There are no immediate plans to add the overhead of `MultiJSON` to this library. With that said, there shouldn't be any conflicts with other JSON libraries you maybe using in your project.
+Please note: As of release 0.1.0, JSON de/serialization is now being handled by the `MultiJSON` gem for compatibility with the widest range of ruby interpreters. For best performance, the preferred implementation is the `Oj` gem.
 
 ## Contributing
 

--- a/dm-postgres-types.gemspec
+++ b/dm-postgres-types.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'dm-types', '~> 1.2.0'
   gem.add_dependency 'dm-validations', '~> 1.2.0'
   gem.add_dependency 'dm-postgres-adapter', '~> 1.2.0'
-  gem.add_dependency 'oj'
+  gem.add_dependency 'multi_json'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake'

--- a/lib/dm-postgres-types.rb
+++ b/lib/dm-postgres-types.rb
@@ -5,7 +5,7 @@ require 'dm-core'
 require 'dm-migrations'
 require 'dm-types'
 require 'dm-postgres-adapter'
-require 'oj'
+require 'multi_json'
 require 'csv'
 
 # lib

--- a/lib/dm-postgres-types/property/pg_json.rb
+++ b/lib/dm-postgres-types/property/pg_json.rb
@@ -18,7 +18,7 @@ module DataMapper
         when ::NilClass, ::String
           value
         when ::Hash, ::Array
-          Oj.dump(value, mode: :compat)
+          MultiJson.dump(value, mode: :compat)
         else
           '{}'
         end
@@ -27,9 +27,9 @@ module DataMapper
       def load(value)
         case value
         when ::Hash, ::Array
-          (load_raw_value) ? Oj.dump(value, mode: :compat) : value
+          (load_raw_value) ? MultiJson.dump(value, mode: :compat) : value
         when ::String
-          (load_raw_value) ? value : Oj.load(value)
+          (load_raw_value) ? value : MultiJson.load(value)
         else
           (load_raw_value) ? '{}' : {}
         end


### PR DESCRIPTION
Despite the lead author's performance concerns, `Oj` isn't available for all interpreters. Proposing a switch to MultiJson to keep this gem broadly compatible.
