### PR TITLE
Avoid errors on values that cannot be `gsub!ed` or `strip!ed`.

### DIFF
--- a/lib/dm-postgres-types/property/pg_hstore.rb
+++ b/lib/dm-postgres-types/property/pg_hstore.rb
@@ -31,8 +31,8 @@ module DataMapper
       end
 
       def unescape_double_quote(value)
-        value.gsub!('"','')
-        value.strip!
+        value.gsub!('"','') if value.respond_to?(:gsub!)
+        value.strip! if value.respond_to?(:strip!)
         value
       end
     end


### PR DESCRIPTION
Avoid gsubbing nil values, or other types such as booleans, integers etc.

Especially since the unescape nil casts to nil and one cannot gsub on
nil. Raising an `NoMethodError: undefined method`gsub!' for
nil:NilClass` exception.
