### PR TITLE
Feature/handle slashes

### DIFF
--- a/lib/dm-postgres-types/property/pg_hstore.rb
+++ b/lib/dm-postgres-types/property/pg_hstore.rb
@@ -31,8 +31,8 @@ module DataMapper
       end
 
       def unescape_double_quote(value)
-        value.gsub!('"','')
-        value.strip!
+        value.gsub!('"','') if value.respond_to?(:gsub!)
+        value.strip! if value.respond_to?(:strip!)
         value
       end
     end

--- a/lib/dm-postgres-types/property/pg_hstore.rb
+++ b/lib/dm-postgres-types/property/pg_hstore.rb
@@ -17,10 +17,14 @@ module DataMapper
 
       def dump(value)
         return "" unless value
-        value.map { |key, val| %Q{"#{key.to_s}"=>"#{escape_nil(val)}"} }.join(", ")
+        value.map { |key, val| %Q{"#{key.to_s}"=>"#{escape(val)}"} }.join(", ")
       end
 
       private
+
+      def escape(value)
+        escape_nil(value).to_s.gsub("\\", "\\\\\\\\")
+      end
 
       def escape_nil(value)
         (value.nil?) ? 'NULL' : value


### PR DESCRIPTION
Note: Follows after previous PR to avoid merge conflicts.

This avoids errors on strings such as "foo\", by escaping them.
